### PR TITLE
Persist user's Nitro framework selection

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,9 +20,9 @@
   "homepage": "https://trongate.io",
   "activationEvents": [
     "onStartupFinished",
-    "onCommand:trongate.selectFramework",
+    "onCommand:trongate.insertSnippet",
     "onCommand:trongate.newTrongate",
-    "onCommand:trongate.selectSnippet"
+    "onCommand:trongate.selectNitroFramework"
   ],
   "main": "./out/extension.js",
   "contributes": {
@@ -40,7 +40,7 @@
     ],
     "commands": [
       {
-        "command": "trongate.selectFramework",
+        "command": "trongate.insertSnippet",
         "title": "Select a front-end framework"
       },
       {
@@ -48,7 +48,7 @@
         "title": "New Trongate Module"
       },
       {
-        "command": "trongate.selectSnippet",
+        "command": "trongate.selectNitroFramework",
         "title": "CSS Framework"
       }
     ],
@@ -116,11 +116,11 @@
         "mac": "ctrl+cmd+alt+/",
         "key": "ctrl+win+alt+/",
         "when": "editorTextFocus",
-        "command": "trongate.selectSnippet"
+        "command": "trongate.selectNitroFramework"
       },
       {
         "key": "ctrl+win+alt+b",
-        "command": "trongate.selectFramework",
+        "command": "trongate.insertSnippet",
         "when": "editorTextFocus",
         "args": {
           "name": "Button"
@@ -128,7 +128,7 @@
       },
       {
         "key": "ctrl+win+alt+u",
-        "command": "trongate.selectFramework",
+        "command": "trongate.insertSnippet",
         "when": "editorTextFocus",
         "args": {
           "name": "Button Alt"
@@ -136,7 +136,7 @@
       },
       {
         "key": "ctrl+win+alt+c",
-        "command": "trongate.selectFramework",
+        "command": "trongate.insertSnippet",
         "when": "editorTextFocus",
         "args": {
           "name": "Contact Form"
@@ -144,7 +144,7 @@
       },
       {
         "key": "ctrl+win+alt+d",
-        "command": "trongate.selectFramework",
+        "command": "trongate.insertSnippet",
         "when": "editorTextFocus",
         "args": {
           "name": "Download URL"
@@ -152,7 +152,7 @@
       },
       {
         "key": "ctrl+win+alt+f",
-        "command": "trongate.selectFramework",
+        "command": "trongate.insertSnippet",
         "when": "editorTextFocus",
         "args": {
           "name": "Form"
@@ -160,7 +160,7 @@
       },
       {
         "key": "ctrl+win+alt+g",
-        "command": "trongate.selectFramework",
+        "command": "trongate.insertSnippet",
         "when": "editorTextFocus",
         "args": {
           "name": "Grid"
@@ -168,7 +168,7 @@
       },
       {
         "key": "ctrl+win+alt+i",
-        "command": "trongate.selectFramework",
+        "command": "trongate.insertSnippet",
         "when": "editorTextFocus",
         "args": {
           "name": "Info Page"
@@ -176,7 +176,7 @@
       },
       {
         "key": "ctrl+win+alt+l",
-        "command": "trongate.selectFramework",
+        "command": "trongate.insertSnippet",
         "when": "editorTextFocus",
         "args": {
           "name": "Login Form"
@@ -184,7 +184,7 @@
       },
       {
         "key": "ctrl+win+alt+m",
-        "command": "trongate.selectFramework",
+        "command": "trongate.insertSnippet",
         "when": "editorTextFocus",
         "args": {
           "name": "Modal"
@@ -193,7 +193,7 @@
       {
         "mac": "ctrl+win+alt+o",
         "key": "ctrl+win+alt+p",
-        "command": "trongate.selectFramework",
+        "command": "trongate.insertSnippet",
         "when": "editorTextFocus",
         "args": {
           "name": "Password Form"
@@ -201,7 +201,7 @@
       },
       {
         "key": "ctrl+win+alt+t",
-        "command": "trongate.selectFramework",
+        "command": "trongate.insertSnippet",
         "when": "editorTextFocus",
         "args": {
           "name": "Table"
@@ -209,7 +209,7 @@
       },
       {
         "key": "ctrl+win+alt+a",
-        "command": "trongate.selectFramework",
+        "command": "trongate.insertSnippet",
         "when": "editorTextFocus",
         "args": {
           "name": "Table Alt"
@@ -217,7 +217,7 @@
       },
       {
         "key": "ctrl+win+alt+e",
-        "command": "trongate.selectFramework",
+        "command": "trongate.insertSnippet",
         "when": "editorTextFocus",
         "args": {
           "name": "Template"

--- a/package.json
+++ b/package.json
@@ -19,12 +19,25 @@
   "icon": "assets/logo.png",
   "homepage": "https://trongate.io",
   "activationEvents": [
+    "onStartupFinished",
     "onCommand:trongate.selectFramework",
     "onCommand:trongate.newTrongate",
     "onCommand:trongate.selectSnippet"
   ],
   "main": "./out/extension.js",
   "contributes": {
+    "configuration":[
+      {
+        "title": "Trongate",
+        "properties": {
+          "trongate.userFrameworkOption": {
+            "type": "string",
+            "default": "Boostrap 4",
+            "description": "User's nitro framework option"
+          }
+        }
+      }
+    ],
     "commands": [
       {
         "command": "trongate.selectFramework",
@@ -101,7 +114,7 @@
     "keybindings": [
       {
         "mac": "ctrl+cmd+alt+/",
-        "key": "ctrl+win+alt+n",
+        "key": "ctrl+win+alt+/",
         "when": "editorTextFocus",
         "command": "trongate.selectSnippet"
       },

--- a/src/commands/switch-frontend-snippet.comand.ts
+++ b/src/commands/switch-frontend-snippet.comand.ts
@@ -1,7 +1,7 @@
 import { QuickPickItem, window } from "vscode";
 
 let items: QuickPickItem[] = [];
-const cssFramework = {
+export const cssFramework = {
   "Boostrap 4": "Boostrap 4 CSS Framework",
   Defiant: "Defiant Frontend Framework",
   Milligram: "Milligram Framework",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -3,14 +3,20 @@
 import * as vscode from "vscode";
 import { newModule } from "./commands";
 import { switchSnippet } from "./commands";
+import {cssFramework} from './commands/switch-frontend-snippet.comand';
 
-let userFrameworkOption = "Boostrap 4";
-// this method is called when your extension is activated
-// your extension is activated the very first time the command is executed
 export function activate(context: vscode.ExtensionContext) {
-  // Use the console to output diagnostic information (console.log) and errors (console.error)
   // This line of code will only be executed once when your extension is activated
   console.log('Congratulations, your extension "trongate" is now active!');
+  // Get the user's nitro framework option
+  let userFrameworkOption = vscode.workspace.getConfiguration().get('trongate.userFrameworkOption');
+  //@ts-ignore
+  if (!Object.keys(cssFramework).includes(userFrameworkOption)) {
+    // If the user messed with the settings, we put them back to default
+    userFrameworkOption = "Bootstrap 4";
+  }
+  vscode.window.setStatusBarMessage(`${userFrameworkOption} in use`);
+  // console.log(vscode.workspace.getConfiguration().get('trongate.userFrameworkOption'))
 
   // The command has been defined in the package.json file
   // Now provide the implementation of the command with registerCommand
@@ -18,9 +24,6 @@ export function activate(context: vscode.ExtensionContext) {
   let nitro = vscode.commands.registerCommand(
     "trongate.selectFramework",
     (args) => {
-      console.log(args);
-      console.log(userFrameworkOption);
-      console.log(" --- --- --- ");
       vscode.commands.executeCommand(`editor.action.insertSnippet`, {
         name: `${userFrameworkOption} ${args.name}`,
       });
@@ -36,16 +39,17 @@ export function activate(context: vscode.ExtensionContext) {
   let selectSnippet = vscode.commands.registerCommand(
     "trongate.selectSnippet",
     // The code you place here will be executed every time your command is executed
-    () => {
+   () => {
       //TODO: Implement the function
       //CURRENTLY:
-      switchSnippet().then((opt) => {
+      switchSnippet().then(async (opt) => {
         if (!opt) {return;}
         //@ts-ignore
         userFrameworkOption = opt;
         vscode.window.showInformationMessage(
           `You have successfully selected ${userFrameworkOption} Framework`
         );
+        await vscode.workspace.getConfiguration().update('trongate.userFrameworkOption', userFrameworkOption, vscode.ConfigurationTarget.Global)
         vscode.window.setStatusBarMessage(`${userFrameworkOption} in use`);
       });
     }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -22,7 +22,7 @@ export function activate(context: vscode.ExtensionContext) {
   // Now provide the implementation of the command with registerCommand
   // The commandId parameter must match the command field in package.json
   let nitro = vscode.commands.registerCommand(
-    "trongate.selectFramework",
+    "trongate.insertSnippet",
     (args) => {
       vscode.commands.executeCommand(`editor.action.insertSnippet`, {
         name: `${userFrameworkOption} ${args.name}`,
@@ -37,7 +37,7 @@ export function activate(context: vscode.ExtensionContext) {
   );
 
   let selectSnippet = vscode.commands.registerCommand(
-    "trongate.selectSnippet",
+    "trongate.selectNitroFramework",
     // The code you place here will be executed every time your command is executed
    () => {
       //TODO: Implement the function


### PR DESCRIPTION
* The patch can remember the user's nitro framework selection, and every time when a new VSCode instance starts, it will load the user's selection first, if the user messes with the settings (it's difficult but possible) then we will put them back to default which is bootstrap 4.

* Status bar will always show the currently in use framework - small hint to the user

* Renamed the command to the more meaningful name
